### PR TITLE
Fix markdown bug in prompt_toolkit_repl.md

### DIFF
--- a/docs/prompt_toolkit_repl.md
+++ b/docs/prompt_toolkit_repl.md
@@ -53,7 +53,6 @@ internally.
     ```python
     import pexpect
 
-
     def test_tui() -> None:
         tui = pexpect.spawn("python source.py", timeout=5)
         tui.expect("Give me .*")
@@ -62,7 +61,7 @@ internally.
 
         with open("/tmp/tui.txt", "r") as f:
             assert f.read() == "HI"
-   ```
+    ```
 
 Where:
 


### PR DESCRIPTION
See https://lyz-code.github.io/blue-book/prompt_toolkit_repl/#using-pexpect